### PR TITLE
fix-app-links

### DIFF
--- a/solutions/jenkins-deploy-from-helm-chart.adoc
+++ b/solutions/jenkins-deploy-from-helm-chart.adoc
@@ -12,7 +12,7 @@ summary: Learn how to deploy Jenkins from the Bitnami Helm chart. After you depl
 
 Learn how to deploy Jenkins from the Bitnami Helm chart. After you deploy Jenkins on your cluster, you can register the application with Astra Control.
 
-Jenkins is a validated app for Astra Control. link:../learn/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
+Jenkins is a validated app for Astra Control. link:../concepts/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
 
 These instructions apply to both Astra Control Service and Astra Control Center.
 

--- a/solutions/mariadb-deploy-from-helm-chart.adoc
+++ b/solutions/mariadb-deploy-from-helm-chart.adoc
@@ -12,7 +12,7 @@ summary: Learn how to deploy MariaDB from the Bitnami Helm chart. After you depl
 
 Learn how to deploy MariaDB from the Bitnami Helm chart. After you deploy MariaDB on your cluster, you can manage the application with Astra Control.
 
-MariaDB is a validated app for Astra. link:../learn/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
+MariaDB is a validated app for Astra. link:../concepts/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
 
 These instructions apply to both Astra Control Service and Astra Control Center.
 

--- a/solutions/mysql-deploy-from-helm-chart.adoc
+++ b/solutions/mysql-deploy-from-helm-chart.adoc
@@ -12,7 +12,7 @@ summary: Learn how to deploy MySQL from the standard stable chart. After you dep
 
 Learn how to deploy MySQL from the https://github.com/helm/charts/tree/master/stable/mysql[standard stable chart^]. After you deploy MySQL on your Kubernetes cluster, you can manage the application with Astra Control.
 
-MySQL is a validated app for Astra Control. link:../learn/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
+MySQL is a validated app for Astra Control. link:../concepts/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
 
 These instructions apply to both Astra Control Service and Astra Control Center.
 

--- a/solutions/postgres-deploy-from-helm-chart.adoc
+++ b/solutions/postgres-deploy-from-helm-chart.adoc
@@ -12,7 +12,7 @@ summary: Learn how to deploy Postgres from a Helm chart. After you deploy Postgr
 
 Learn how to deploy Postgres from the Bitnami Helm chart. After you deploy Postgres on your cluster, you can register the application with Astra Control.
 
-Postgres is a validated app for Astra. link:../learn/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
+Postgres is a validated app for Astra. link:../concepts/validated-vs-standard.html[Learn the difference between Validated and Standard apps].
 
 These instructions apply to both Astra Control Service and Astra Control Center.
 


### PR DESCRIPTION
The links for the validated vs standard apps were incorrect on all 4 pages.  moved from learn to concepts  where the page exists.