### PR TITLE
Fixed type in kube-rbac-proxy image name

### DIFF
--- a/get-started/install_acc.adoc
+++ b/get-started/install_acc.adoc
@@ -155,7 +155,7 @@ imagePullSecrets:
 - name: astra-registry-cred
 ----
 
-.. Change `[Docker_registry_path]` for the `kube-rbac-prox` image to the registry path where you pushed the images in a previous step.
+.. Change `[Docker_registry_path]` for the `kube-rbac-proxy` image to the registry path where you pushed the images in a previous step.
 .. Change `[Docker_registry_path]` for the `acc-operator-controller-manager` image to the registry path where you pushed the images in a previous step.
 
 +


### PR DESCRIPTION
This PR addresses a small typo in the image name "kube-rbac-proxy" in the installation instructions.