### PR TITLE
Doc 4217 app management reqs

### DIFF
--- a/use/manage-apps.adoc
+++ b/use/manage-apps.adoc
@@ -12,7 +12,7 @@ summary: After you add Kubernetes clusters to Astra Control, you can install app
 
 After you link:../get-started/setup_overview.html#add-cluster[add a cluster to Astra Control management], you can install apps on the cluster (outside of Astra Control) and then go to the Applications page in Astra Control to start managing the apps and their resources.
 
-Before you start managing your apps, make sure you meet the link:../get-started/requirements.html#application-management-requirements[App management requirements].
+For more information, see link:../get-started/requirements.html#application-management-requirements[App management requirements].
 
 === Supported app installation methods
 Astra Control supports the following application installation methods:

--- a/use/manage-apps.adoc
+++ b/use/manage-apps.adoc
@@ -12,52 +12,7 @@ summary: After you add Kubernetes clusters to Astra Control, you can install app
 
 After you link:../get-started/setup_overview.html#add-cluster[add a cluster to Astra Control management], you can install apps on the cluster (outside of Astra Control) and then go to the Applications page in Astra Control to start managing the apps and their resources.
 
-== App management requirements
-Astra Control has the following app management requirements:
-
-* *Licensing*: To manage apps using Astra Control Center, you need an Astra Control Center license.
-* *Namespaces*: Astra Control requires that an app not span more than a single namespace, but a namespace can contain more than one app.
-* *StorageClass*: If you install an app with a StorageClass explicitly set and you need to clone the app, the target cluster for the clone operation must have the originally specified StorageClass. Cloning an application with an explicitly set StorageClass to a cluster that does not have the same StorageClass will fail.
-* *Kubernetes resources*: Apps that use Kubernetes Resources not collected by Astra Control might not have full app data management capabilities. Astra Control collects the following Kubernetes resources:
-+
-[cols="1,1,1"]
-|===
-|ClusterRole
-|ClusterRoleBinding
-|ConfigMap
-
-|CustomResourceDefinition
-|CustomResource
-|CronJob
-
-|DaemonSet
-|HorizontalPodAutoscaler
-|Ingress
-
-|DeploymentConfig
-|MutatingWebhook
-|PersistentVolumeClaim
-
-|Pod
-|PodDisruptionBudget
-|PodTemplate
-
-|NetworkPolicy
-|ReplicaSet
-|Role
-
-|RoleBinding
-|Route
-|Secret
-
-|Service
-|ServiceAccount
-|StatefulSet
-
-|ValidatingWebhook
-|
-|
-|===
+Before you start managing your apps, make sure you meet the link:../get-started/requirements.html#application-management-requirements[App management requirements].
 
 === Supported app installation methods
 Astra Control supports the following application installation methods:


### PR DESCRIPTION
Removed the requirements from the Start managing apps topic and replaced with a link to the Requirements page.