### PR TITLE
install_acc.adoc

### DIFF
--- a/get-started/install_acc.adoc
+++ b/get-started/install_acc.adoc
@@ -132,7 +132,7 @@ cd acc
 +
 [source,sh]
 ----
-kubectl astra packages push-images -m BUNDLE_FILE -r MY_REGISTRY -u MY_REGISTRY_USER -p MY_REGISTRY_TOKEN
+kubectl-astra packages push-images -m BUNDLE_FILE -r MY_REGISTRY -u MY_REGISTRY_USER -p MY_REGISTRY_TOKEN
 ----
 --
 


### PR DESCRIPTION
There is a typo error in the docker push command, which is in pushing all the docker images to private registry.